### PR TITLE
Add ARP spoofing detection

### DIFF
--- a/src/test_arp.py
+++ b/src/test_arp.py
@@ -1,0 +1,34 @@
+import unittest
+import main
+from scapy.layers.all import ARP
+from scapy.layers.inet import Ether
+
+
+class TestSignature(unittest.TestCase):
+    def test_negative(self):
+        with self.assertNoLogs():
+            pkt = Ether(dst="ff:ff:ff:ff:ff:ff") / ARP(
+                op="is-at", hwsrc="60:b5:8d:8d:3e:7c", psrc="192.168.1.30"
+            )
+            main.packet_handler(pkt)
+            main.packet_handler(pkt)
+
+    def test_positive(self):
+        with self.assertLogs() as log:
+            pkt1 = Ether(dst="ff:ff:ff:ff:ff:ff") / ARP(
+                op="is-at", hwsrc="60:b5:8d:8d:3e:7c", psrc="192.168.1.31"
+            )
+            main.packet_handler(pkt1)
+            pkt2 = Ether(dst="ff:ff:ff:ff:ff:ff") / ARP(
+                op="is-at", hwsrc="60:b5:8d:8d:3e:7d", psrc="192.168.1.31"
+            )
+            main.packet_handler(pkt2)
+            self.assertEqual(
+                log.output,
+                [
+                    "WARNING:root:Malicious Packet Detected: ARP spoofing detected\n"
+                    "MAC Address of malicious agent: 00:00:00:00:00:00\n"
+                    "Source IP: N/A, Destination IP: N/A\n"
+                    "Source Port: N/A, Destination Port: N/A"
+                ],
+            )


### PR DESCRIPTION
Detects when there are ARP `is-at` responses, but the MAC addresses don't match. This is likely because someone is trying to intercept IP traffic.