### PR TITLE
Add TCP handshake check

### DIFF
--- a/src/tcp.py
+++ b/src/tcp.py
@@ -1,0 +1,15 @@
+class TcpConnection:
+    def __init__(self):
+        self.state = "initial"
+        pass
+
+
+tcp_connections = dict()
+
+
+# in some tests, we're not performing a TCP handshake, but that
+# shouldn't matter, so we can ignore it with this method
+def tcp_handshake_ignore(src: str, dst: str, sport: int, dport: int):
+    conn = TcpConnection()
+    conn.state = "ack"
+    tcp_connections[(src, dst, sport, dport)] = conn

--- a/src/test_utils.py
+++ b/src/test_utils.py
@@ -1,0 +1,9 @@
+from scapy.layers.inet import IP, TCP
+from scapy.packet import Packet
+import main
+
+
+def send_test_tcp_packet(packet: Packet):
+    packet[IP].chksum = IP(bytes(packet[IP])).chksum
+    packet[TCP].chksum = TCP(bytes(packet[TCP])).chksum
+    main.packet_handler(packet)


### PR DESCRIPTION
Keeps track of open TCP connections, and verifies that the clients send packets with the correct flags (SYN, SYN-ACK, ACK).