### PR TITLE
Reduce false positives with ML IDS

### DIFF
--- a/src/check/checksum.py
+++ b/src/check/checksum.py
@@ -21,7 +21,9 @@ class Checksum(Check):
             if original_checksum != recalculated_checksum:
                 Logger.log_malicious_packet(packet, "Invalid IP checksum.")
 
-        if TCP in packet:
+        if IP in packet and TCP in packet:
+            # TODO: this does not work correctly for IPv6,
+            # so we restrict it to IP for now
             original_checksum = packet[
                 TCP
             ].chksum  # saves original checksum for comparison

--- a/src/checker.py
+++ b/src/checker.py
@@ -1,5 +1,5 @@
 from scapy.layers.l2 import ARP
-from scapy.layers.inet import IP, TCP
+from scapy.layers.inet import IP, TCP, UDP
 
 from src.check.ip.ip_spoofing import IpSpoofing
 from src.check.ip.destination import Destination
@@ -14,6 +14,7 @@ from src.check.signature import Signature
 from src.check.checksum import Checksum
 from src.check.dns_spoofing import DnsSpoofing
 from src.check.malformed_packet import MalformedPacket
+from src.check.udp.anomaly import UdpAnomaly
 
 
 class Checker:
@@ -21,6 +22,7 @@ class Checker:
         DnsSpoofing.update_malicious_ips()
         FragmentOverlap.init()
         self.ip_checks = [IpSpoofing, Destination, IcmpFlood, FragmentOverlap]
+        self.udp_checks = [UdpAnomaly]
         self.tcp_checks = [Connection, Flag, NullPacket, PortCheck]
 
         self.arp_checks = [ArpSpoofing]
@@ -35,6 +37,10 @@ class Checker:
         if TCP in packet:
             for tcp_check in self.tcp_checks:
                 tcp_check.check(packet)
+
+        if UDP in packet:
+            for udp_check in self.udp_checks:
+                udp_check.check(packet)
 
         if ARP in packet:
             for arp_check in self.arp_checks:


### PR DESCRIPTION
Mostly due to the way we handled reset connections, we got tons of false positives. I believe there's something in the way HTTPS is handled that causes lots of resets, which just wasn't there when NSL KDD was developed.
Now, we just drop reset connections, which makes everything way more robust.